### PR TITLE
fixed display of resource place name (mockdata)

### DIFF
--- a/labgrid-web-client/src/app/_services/place.service.ts
+++ b/labgrid-web-client/src/app/_services/place.service.ts
@@ -29,8 +29,8 @@ export class PlaceService {
 
     public async getPlaces(): Promise<Place[]> {
         // If the python-wamp-client is not available the following lines can be used to load test data
-        // let mockPlaces = await this._http.get('../../assets/places.json').toPromise() as Place[]
-        // return mockPlaces 
+        // let mockPlaces = await this._http.get('../../assets/places.json').toPromise() as Place[];
+        // return mockPlaces; 
 
         // If the session is already set the places can immediately be read.
         // Otherwise we wait 1 second.
@@ -50,12 +50,12 @@ export class PlaceService {
 
     public async getPlace(placeName: string): Promise<Place> {
         // If the python-wamp-client is not available the following lines can be used to load test data
-        // let mockPlaces = await this._http.get('../../assets/places.json').toPromise() as Place[]
-        // let mockPlace = mockPlaces.find(element => element.name === placeName)
+        // let mockPlaces = await this._http.get('../../assets/places.json').toPromise() as Place[];
+        // let mockPlace = mockPlaces.find(element => element.name === placeName);
         // if (!mockPlace){
-        //     throw new Error('No such place')
+        //     throw new Error('No such place');
         // }
-        // return mockPlace
+        // return mockPlace;
 
         // If the session is already set the places can immediately be read.
         // Otherwise we wait 1 second.

--- a/labgrid-web-client/src/app/_services/place.service.ts
+++ b/labgrid-web-client/src/app/_services/place.service.ts
@@ -5,13 +5,15 @@ import { AllocationState } from '../_enums/allocation-state';
 
 import * as autobahn from 'autobahn-browser';
 
+import { HttpClient } from '@angular/common/http';
+
 @Injectable({
     providedIn: 'root',
 })
 export class PlaceService {
     private session: any;
 
-    constructor(/*private _http: HttpClient*/) {
+    constructor(private _http: HttpClient) {
         const connection = new autobahn.Connection({
             url: 'ws://localhost:8083/ws',
             realm: 'frontend',
@@ -26,6 +28,10 @@ export class PlaceService {
     }
 
     public async getPlaces(): Promise<Place[]> {
+        // If the python-wamp-client is not available the following lines can be used to load test data
+        // let mockPlaces = await this._http.get('../../assets/places.json').toPromise() as Place[]
+        // return mockPlaces 
+
         // If the session is already set the places can immediately be read.
         // Otherwise we wait 1 second.
         if (this.session) {
@@ -40,11 +46,17 @@ export class PlaceService {
             return places;
         }
 
-        // If the python-wamp-client is not available the following line can be used to load test data
-        // const places = await this._http.get('../assets/places.json').toPromise() as Place[];
     }
 
     public async getPlace(placeName: string): Promise<Place> {
+        // If the python-wamp-client is not available the following lines can be used to load test data
+        // let mockPlaces = await this._http.get('../../assets/places.json').toPromise() as Place[]
+        // let mockPlace = mockPlaces.find(element => element.name === placeName)
+        // if (!mockPlace){
+        //     throw new Error('No such place')
+        // }
+        // return mockPlace
+
         // If the session is already set the places can immediately be read.
         // Otherwise we wait 1 second.
         if (this.session) {
@@ -69,8 +81,6 @@ export class PlaceService {
             return place;
         }
 
-        // If the python-wamp-client is not available the following line can be used to load test data
-        // const place = await this.session.call('localhost.places');
     }
 
     public async acquirePlace(placeName: string): Promise<boolean> {

--- a/labgrid-web-client/src/app/_services/resource.service.ts
+++ b/labgrid-web-client/src/app/_services/resource.service.ts
@@ -48,7 +48,7 @@ export class ResourceService {
         // If the python-wamp-client is not available the following lines can be used to load test data
         // const resources = await this._http.get('../assets/resources.json').toPromise() as Resource[];
         // const matchingResources = resources.filter(element => element.acquired === placeName);
-        // return matchingResources
+        // return matchingResources;
 
         // If the session is already set the places can immediately be read.
         // Otherwise we wait 1 second.
@@ -72,10 +72,10 @@ export class ResourceService {
         // const resources = await this._http.get('../assets/resources.json').toPromise() as Resource[];
         // const match = resources.find(element => element.name === resourceName && element.acquired === placeName.trim());
         // if (!match){
-        //     throw new Error('No such match')
+        //     throw new Error('No such match');
         // }
-        // match.place = match.acquired
-        // return match
+        // match.place = match.acquired;
+        // return match;
 
         // If the session is already set the places can immediately be read.
         // Otherwise we wait 1 second.

--- a/labgrid-web-client/src/app/_services/resource.service.ts
+++ b/labgrid-web-client/src/app/_services/resource.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { Resource } from '../../models/resource';
 
 import * as autobahn from 'autobahn-browser';
+import { HttpClient } from '@angular/common/http';
 
 @Injectable({
     providedIn: 'root',
@@ -9,7 +10,7 @@ import * as autobahn from 'autobahn-browser';
 export class ResourceService {
     private session: any;
 
-    constructor(/*private _http: HttpClient*/) {
+    constructor(private _http: HttpClient) {
         const connection = new autobahn.Connection({
             url: 'ws://localhost:8083/ws',
             realm: 'frontend',
@@ -24,6 +25,9 @@ export class ResourceService {
     }
 
     public async getResources(): Promise<Resource[]> {
+        // If the python-wamp-client is not available the following line can be used to load test data
+        // const resources = await this._http.get('../assets/resources.json').toPromise() as Resource[];
+
         // If the session is already set the places can immediately be read.
         // Otherwise we wait 1 second.
         if (this.session) {
@@ -38,11 +42,14 @@ export class ResourceService {
             return resources;
         }
 
-        // If the python-wamp-client is not available the following line can be used to load test data
-        // const resources = await this._http.get('../assets/resources.json').toPromise() as Resource[];
     }
 
     public async getResourcesForPlace(placeName: string): Promise<Resource[]> {
+        // If the python-wamp-client is not available the following lines can be used to load test data
+        // const resources = await this._http.get('../assets/resources.json').toPromise() as Resource[];
+        // const matchingResources = resources.filter(element => element.acquired === placeName);
+        // return matchingResources
+
         // If the session is already set the places can immediately be read.
         // Otherwise we wait 1 second.
         if (this.session) {
@@ -57,12 +64,19 @@ export class ResourceService {
             return resources;
         }
 
-        // If the python-wamp-client is not available the following line can be used to load test data
-        // const resources = await this._http.get('../assets/resources.json').toPromise() as Resource[];
-        // const matchingResources = resources.filter(element => element.acquired === resourceName);
     }
 
-    public async getResourceByName(resourceName: string): Promise<Resource> {
+    public async getResourceByName(resourceName: string, placeName: string): Promise<Resource> {
+
+        // If the python-wamp-client is not available the following lines can be used to load test data
+        // const resources = await this._http.get('../assets/resources.json').toPromise() as Resource[];
+        // const match = resources.find(element => element.name === resourceName && element.acquired === placeName.trim());
+        // if (!match){
+        //     throw new Error('No such match')
+        // }
+        // match.place = match.acquired
+        // return match
+
         // If the session is already set the places can immediately be read.
         // Otherwise we wait 1 second.
         if (this.session) {
@@ -83,8 +97,5 @@ export class ResourceService {
             return result[0];
         }
 
-        // If the python-wamp-client is not available the following line can be used to load test data
-        // const resources = await this._http.get('../assets/resources.json').toPromise() as Resource[];
-        // const match = resources.find(element => element.name === resourceName);
     }
 }

--- a/labgrid-web-client/src/app/app.module.ts
+++ b/labgrid-web-client/src/app/app.module.ts
@@ -28,6 +28,7 @@ import { ResourceService } from './_services/resource.service';
 import { ResourceComponent } from './resource/resource.component';
 import { ResourceOverviewComponent } from './resource-overview/resource-overview.component';
 import { PlaceOverviewComponent } from './place-overview/place-overview.component';
+import { HttpClientModule } from '@angular/common/http';
 
 @NgModule({
     declarations: [
@@ -43,6 +44,7 @@ import { PlaceOverviewComponent } from './place-overview/place-overview.componen
         BrowserModule,
         AppRoutingModule,
         BrowserAnimationsModule,
+        HttpClientModule,
         MatIconModule,
         MatSidenavModule,
         MatToolbarModule,

--- a/labgrid-web-client/src/app/place-overview/place-overview.component.html
+++ b/labgrid-web-client/src/app/place-overview/place-overview.component.html
@@ -25,7 +25,7 @@
                 <span
                     class="resource-label"
                     *ngFor="let resource of place.acquired_resources"
-                    (click)="navigateToResource(resource[3])"
+                    (click)="navigateToResource(resource[3], $event)"
                 >
                     {{ resource[3] }}
                 </span>

--- a/labgrid-web-client/src/app/place-overview/place-overview.component.ts
+++ b/labgrid-web-client/src/app/place-overview/place-overview.component.ts
@@ -47,7 +47,8 @@ export class PlaceOverviewComponent implements OnInit {
         this.router.navigate(['place/', placeName]);
     }
 
-    navigateToResource(resourceName: string) {
-        this.router.navigate(['resource/', resourceName]);
+    navigateToResource(resourceName: string, event: Event) {
+        const correspondingPlace = (event.currentTarget as HTMLInputElement).parentNode?.parentNode?.firstChild?.textContent;
+        this.router.navigate(['resource/', resourceName, {placeName: correspondingPlace}]);
     }
 }

--- a/labgrid-web-client/src/app/place/place.component.ts
+++ b/labgrid-web-client/src/app/place/place.component.ts
@@ -52,7 +52,7 @@ export class PlaceComponent implements OnInit {
     }
 
     public navigateToResource(resourceName: string) {
-        this.router.navigate(['resource/', resourceName]);
+        this.router.navigate(['resource/', resourceName, {placeName: this.place.name}]);
     }
 
     private readPlaceState(): void {

--- a/labgrid-web-client/src/app/resource/resource.component.ts
+++ b/labgrid-web-client/src/app/resource/resource.component.ts
@@ -20,7 +20,16 @@ export class ResourceComponent implements OnInit {
     constructor(private _rs: ResourceService, private route: ActivatedRoute) {
         route.params.subscribe(() => {
             const resourceName = route.snapshot.url[route.snapshot.url.length - 1].path;
-            this._rs.getResourceByName(resourceName).then((data) => {
+            // const placeName = this.route.snapshot.paramMap.get('placeName');
+            // if (!placeName) {
+            //     throw new Error('No place name provided')
+            // }
+            // this._rs.getResourceByName(resourceName, placeName).then((data) => {
+            //     this.resource = data;
+            //     this.readResourceAttributes();
+            // });
+
+            this._rs.getResourceByName(resourceName, 'placeholdername').then((data) => {
                 this.resource = data;
                 this.readResourceAttributes();
             });

--- a/labgrid-web-client/src/assets/places.json
+++ b/labgrid-web-client/src/assets/places.json
@@ -1,6 +1,6 @@
 [
     {
-        "acquired": "cup/dummy",
+        "acquired": "cup/dummy1",
         "acquired_resources": [
             ["cup", "mle-lg-ref-1", "NetworkService", "NetworkService"],
             ["cup", "mle-lg-ref-1", "PDUDaemonPort", "PDUDaemonPort"],
@@ -11,6 +11,43 @@
         ],
         "isRunning": true,
         "name": "mle-lg-ref-1",
+        "matches": [
+            {
+                "cls": "*",
+                "exporter": "*",
+                "group": "mle-lg-ref-1",
+                "name": null,
+                "rename": null
+            }
+        ],
+        "reservation": null
+    },
+    {
+        "acquired": "cup/dummy2",
+        "acquired_resources": [
+            ["cup", "mle-lg-ref-2", "NetworkService", "NetworkService"],
+            ["cup", "mle-lg-ref-2", "NetworkUSBSDMuxDevice", "USBSDMuxDevice"]
+        ],
+        "isRunning": true,
+        "name": "mle-lg-ref-2",
+        "matches": [
+            {
+                "cls": "*",
+                "exporter": "*",
+                "group": "mle-lg-ref-1",
+                "name": null,
+                "rename": null
+            }
+        ],
+        "reservation": null
+    },
+    {
+        "acquired": "cup/dummy3",
+        "acquired_resources": [
+            ["cup", "mle-lg-ref-3", "NetworkService", "NetworkService"]
+        ],
+        "isRunning": true,
+        "name": "mle-lg-ref-3",
         "matches": [
             {
                 "cls": "*",

--- a/labgrid-web-client/src/assets/resources.json
+++ b/labgrid-web-client/src/assets/resources.json
@@ -102,5 +102,162 @@
             "log_level": ["events", "protocol"],
             "serial": ""
         }
+    },
+    {
+        "name": "USBSerialPort",
+        "matches": "cup/mle-lg-ref-1/NetworkSerialPort/USBSerialPort",
+        "acquired": "mle-lg-ref-1",
+        "avail": true,
+        "cls": "NetworkSerialPort",
+        "params": {
+            "extra": {
+                "path": "/dev/ttyUSB0",
+                "proxy": "cup.mle",
+                "proxy_required": false
+            },
+            "host": "cup",
+            "port": 36393,
+            "speed": 115200
+        }
+    },
+    {
+        "name": "PDUDaemonPort",
+        "matches": "cup/mle-lg-ref-1/PDUDaemonPort/PDUDaemonPort",
+        "acquired": "mle-lg-ref-1",
+        "avail": true,
+        "cls": "PDUDaemonPort",
+        "params": {
+            "host": "brett.mle",
+            "index": 1,
+            "pdu": "sonoff-5.mle"
+        }
+    },
+    {
+        "name": "USBVideo",
+        "matches": "cup/mle-lg-ref-1/NetworkUSBVideo/USBVideo",
+        "acquired": "mle-lg-ref-1",
+        "avail": true,
+        "cls": "NetworkUSBVideo",
+        "params": {
+            "busnu,": 3,
+            "devnum": 4,
+            "extra": {
+                "proxy": "cup.mle",
+                "proxy_required": false
+            },
+            "host": "cup",
+            "model_id": 2093,
+            "path": "/dev/video1",
+            "vendor_id": 1133
+        }
+    },
+    {
+        "name": "USBSDMuxDevice",
+        "matches": "cup/mle-lg-ref-1/NetworkUSBSDMuxDevice/USBSDMuxDevice",
+        "acquired": "mle-lg-ref-1",
+        "avail": true,
+        "cls": "NetworkUSBSDMuxDevice",
+        "params": {
+            "busnu,": 3,
+            "control_path": "/dev/sg2",
+            "devnum": 9,
+            "extra": {
+                "proxy": "cup.mle",
+                "proxy_required": false
+            },
+            "host": "cup",
+            "model_id": 16449,
+            "path": "/dev/sdb",
+            "vendor_id": 1060
+        }
+    },
+    {
+        "name": "NetworkService",
+        "matches": "cup/mle-lg-ref-1/NetworkService/NetworkService",
+        "acquired": "mle-lg-ref-1",
+        "avail": true,
+        "cls": "NetworkService",
+        "params": {
+            "address": "10.89.228.85",
+            "extra": {
+                "proxy": "cup.mle",
+                "proxy_required": false
+            },
+            "password": "root",
+            "username": "root"
+        }
+    },
+    {
+        "name": "XilinxUSBJTAG",
+        "matches": "cup/mle-lg-ref-1/NetworkXilinxUSBJTAG/XilinxUSBJTAG",
+        "acquired": "mle-lg-ref-1",
+        "avail": false,
+        "cls": "NetworkXilinxUSBJTAG",
+        "params": {
+            "agent_url": "tcp::3122",
+            "extra": {
+                "proxy": "cup.mle",
+                "proxy_required": false
+            },
+            "extra_args": ["-S"],
+            "gdb_port": 4000,
+            "host": "cup",
+            "hw_server_cmd": ["source ", "/opt/xilinx/mle-hwse/v2020.1/Vivado/2020.1/settings64.sh ", "&& hw_server"],
+            "log_level": ["events", "protocol"],
+            "serial": ""
+        }
+    },
+    {
+        "name": "USBSDMuxDevice",
+        "matches": "cup/mle-lg-ref-2/NetworkUSBSDMuxDevice/USBSDMuxDevice",
+        "acquired": "mle-lg-ref-2",
+        "avail": true,
+        "cls": "NetworkUSBSDMuxDevice",
+        "params": {
+            "busnu,": 3,
+            "control_path": "/dev/sg2",
+            "devnum": 9,
+            "extra": {
+                "proxy": "cup.mle",
+                "proxy_required": false
+            },
+            "host": "cup",
+            "model_id": 16449,
+            "path": "/dev/sdb",
+            "vendor_id": 1060
+        }
+    },
+    {
+        "name": "NetworkService",
+        "matches": "cup/mle-lg-ref-2/NetworkService/NetworkService",
+        "acquired": "mle-lg-ref-2",
+        "avail": true,
+        "cls": "NetworkService",
+        "params": {
+            "address": "10.89.228.85",
+            "extra": {
+                "proxy": "cup.mle",
+                "proxy_required": false
+            },
+            "password": "root",
+            "username": "root"
+        }
+    },
+    {
+        "name": "NetworkService",
+        "matches": "cup/mle-lg-ref-3/NetworkService/NetworkService",
+        "acquired": "mle-lg-ref-3",
+        "avail": true,
+        "cls": "NetworkService",
+        "params": {
+            "address": "10.89.228.85",
+            "extra": {
+                "proxy": "cup.mle",
+                "proxy_required": false
+            },
+            "password": "root",
+            "username": "root"
+        }
     }
+    
 ]


### PR DESCRIPTION
When opening a resource component, the place name was wrong, because the resource name is not unique. This caused the place name to always be the first place that aquired a resource of that name.

This fix additionaly uses the corresponding place name when navigating to a resource. This only works for mockdata currently as the actual call only uses the resource name, not the place name.