### PR TITLE
fixed cache poisoning on wrong entry

### DIFF
--- a/python-wamp-client/labby/rpc.py
+++ b/python-wamp-client/labby/rpc.py
@@ -72,7 +72,8 @@ def cached(attribute: str):
                     attribute)
             if data is None:
                 data: Optional[Dict] = await func(context, *args, **kwargs)
-                context.__setattr__(attribute, data)
+                if not isinstance(data, LabbyError):
+                    context.__setattr__(attribute, data)
             return data
 
         return wrapped


### PR DESCRIPTION
# Fixed

* when rpc returns LabbyError the cache is set to Labby error, which prevents any further rpc from succeeding.