### PR TITLE
Merge pull request #118 from Simon-Deuring/feature/reserve-places-33

### DIFF
--- a/labgrid-web-client/src/app/_services/place.service.ts
+++ b/labgrid-web-client/src/app/_services/place.service.ts
@@ -98,7 +98,7 @@ export class PlaceService {
         }
     }
 
-    public async reservePlace(placeName: string): Promise<boolean> {
+    public async reservePlace(placeName: string): Promise<any> {
         let result = await this.session.call('localhost.create_reservation', [placeName]);
         return result;
     }

--- a/labgrid-web-client/src/app/place/place.component.ts
+++ b/labgrid-web-client/src/app/place/place.component.ts
@@ -155,16 +155,16 @@ export class PlaceComponent {
     }
 
     public async reservePlace() {
-        const ret = await this._ps.reservePlace(this.route.snapshot.url[this.route.snapshot.url.length - 1].path);
-        if (ret === null) {
+        const ret: any = await this._ps.reservePlace(this.route.snapshot.url[this.route.snapshot.url.length - 1].path);
+        if (ret.error !== undefined && ret.error.message !== undefined) {
+            this._snackBar.open(ret.error.message, 'OK', {
+                duration: 3000,
+                panelClass: ['error-snackbar'],
+            });
+        } else {
             this._snackBar.open('Place has been reserved succesfully!', 'OK', {
                 duration: 3000,
                 panelClass: ['success-snackbar'],
-            });
-        } else {
-            this._snackBar.open('An error has occured during the reservation!', 'OK', {
-                duration: 3000,
-                panelClass: ['error-snackbar'],
             });
         }
     }

--- a/labgrid-web-client/src/app/sidebar/sidebar.component.ts
+++ b/labgrid-web-client/src/app/sidebar/sidebar.component.ts
@@ -34,7 +34,13 @@ export class SidebarComponent implements OnInit {
     }
 
     navigateToPlace(placeName: string) {
-        this._router.navigate(['place/', placeName]);
+        if (this._router.url.startsWith('/place/')) {
+            this._router
+                .navigateByUrl('/', { skipLocationChange: true })
+                .then(() => this._router.navigate(['place/', placeName]));
+        } else {
+            this._router.navigate(['place/', placeName]);
+        }
     }
 
     navigateToResources() {

--- a/python-wamp-client/labby/labby.py
+++ b/python-wamp-client/labby/labby.py
@@ -12,7 +12,7 @@ import autobahn.wamp.exception as wexception
 
 from .rpc import (cancel_reservation, create_place, create_resource,
                   delete_place, delete_resource, forward, get_alias, get_exporters, invalidates_cache,
-                  places, places_names, get_reservations, create_reservation, resource, power_state,
+                  places, places_names, get_reservations, create_reservation, poll_reservation, resource, power_state,
                   acquire, release, info, resource_by_name, resource_overview)
 from .router import Router
 from .labby_types import GroupName, PlaceName, ResourceName, Session
@@ -62,6 +62,10 @@ class LabbyClient(Session):
         res = await self.call("wamp.registration.list")
         for proc in res['exact']:
             p = await self.call("wamp.registration.get", proc)
+            print(p['uri'])
+        res = await self.call("wamp.subscription.list")
+        for proc in res['exact']:
+            p = await self.call("wamp.subscription.get", proc)
             print(p['uri'])
 
         self.subscribe(self.on_place_changed,
@@ -167,15 +171,16 @@ class RouterInterface(ApplicationSession):
         self.register("power_state", power_state)
         self.register("acquire", acquire)
         self.register("release", release)
-        self.register("get_reservations", get_reservations)
         self.register("resource_overview", resource_overview)
         self.register("resource_by_name", resource_by_name)
         self.register("info", info)
         self.register("forward", forward)
         self.register("create_place", create_place)
         self.register("delete_place", delete_place)
+        self.register("get_reservations", get_reservations)
         self.register("create_reservation", create_reservation)
         self.register("cancel_reservation", cancel_reservation)
+        self.register("poll_reservation", poll_reservation)
         self.register("create_resource", create_resource)
         self.register("delete_resource", delete_resource)
         self.register("place_names", places_names)

--- a/python-wamp-client/labby/labby.py
+++ b/python-wamp-client/labby/labby.py
@@ -132,8 +132,9 @@ class LabbyClient(Session):
             place_data
             and place_data['acquired'] is not None
             and place_data['acquired'] == self.user_name
+            and name not in self.acquired_places
         ):
-            self.acquired_places.append(name)
+            self.acquired_places.add(name)
 
 
 class RouterInterface(ApplicationSession):

--- a/python-wamp-client/labby/labby.py
+++ b/python-wamp-client/labby/labby.py
@@ -72,7 +72,8 @@ class LabbyClient(Session):
                        "org.labgrid.coordinator.place_changed")
         self.subscribe(self.on_resource_changed,
                        "org.labgrid.coordinator.resource_changed")
-        asyncio.run_coroutine_threadsafe(refresh_reservations(self), asyncio.get_event_loop())
+        asyncio.create_task(refresh_reservations(self))
+        # asyncio.run_coroutine_threadsafe(refresh_reservations(self), asyncio.get_event_loop())
 
     def onLeave(self, details):
         self.log.info("Coordinator session disconnected.")

--- a/python-wamp-client/labby/labby.py
+++ b/python-wamp-client/labby/labby.py
@@ -41,6 +41,7 @@ class LabbyClient(Session):
     def __init__(self, config=None):
         # make sure only one active labby client exists
         globals()["CALLBACK_REF"] = self
+        self.user_name = "labby/dummy"
         super().__init__(config=config)
 
     def onConnect(self):
@@ -127,6 +128,12 @@ class LabbyClient(Session):
             place = self.places[name]
             place.update(place_data)
             self.log.info(f"Place {name} changed.")
+        if (# add place to acquired places, if we have acquired it previously
+            place_data
+            and place_data['acquired'] is not None
+            and place_data['acquired'] == self.user_name
+        ):
+            self.acquired_places.append(name)
 
 
 class RouterInterface(ApplicationSession):
@@ -197,7 +204,7 @@ def run_router(backend_url: str, backend_realm: str, frontend_url: str, frontend
 
     globals()["LOADED_RPC_FUNCTIONS"] = {}
     logging.basicConfig(
-        level="WARNING", format="%(asctime)s [%(name)s][%(levelname)s] %(message)s")
+        level="DEBUG", format="%(asctime)s [%(name)s][%(levelname)s] %(message)s")
 
     labby_runner = ApplicationRunner(
         url=backend_url, realm=backend_realm, extra=None)

--- a/python-wamp-client/labby/labby_types.py
+++ b/python-wamp-client/labby/labby_types.py
@@ -3,7 +3,7 @@ Types used throughout labby
 """
 
 from abc import abstractmethod
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 from autobahn.asyncio.wamp import ApplicationSession
 from attr import attrs, attrib
 
@@ -31,6 +31,7 @@ class Session(ApplicationSession):
         self.acquired_places: List = []
         self.power_states: Optional[List] = None
         self.reservations: Dict = {}
+        self.to_refresh: Set = set()
         super().__init__(*args, **kwargs)
 
 

--- a/python-wamp-client/labby/labby_types.py
+++ b/python-wamp-client/labby/labby_types.py
@@ -3,6 +3,7 @@ Types used throughout labby
 """
 
 from abc import abstractmethod
+from enum import Enum
 from typing import Dict, List, Optional, Set, Tuple
 from autobahn.asyncio.wamp import ApplicationSession
 from attr import attrs, attrib
@@ -29,7 +30,7 @@ class Session(ApplicationSession):
     def __init__(self, *args, **kwargs) -> None:
         self.resources: Optional[Dict] = None
         self.places: Optional[Dict] = None
-        self.acquired_places: List[PlaceName] = []
+        self.acquired_places: Set[PlaceName] = set()
         self.power_states: Optional[List] = None
         self.reservations: Dict = {}
         self.to_refresh: Set = set()
@@ -58,4 +59,38 @@ class LabbyPlace(LabbyType):
             "acquired_resources": self.acquired_resources,
             "exporter": self.exporter,
             "power_state": self.power_state,
+        }
+
+# pylint: disable=invalid-name
+class _ReservationState(Enum):
+    waiting = 0
+    allocated = 1
+    acquired = 2
+    expired = 3
+    invalid = 4
+
+@attrs
+class LabbyReservation(LabbyType):
+    owner : str = attrib(default=None,)
+    token : str = attrib(default=None,)
+    state : _ReservationState = attrib(default=None,)
+    prio : float = attrib(default=None,)
+    filters : Dict[str, Dict[str, str]]= attrib(default=None,)
+    allocations : Dict[str, str] = attrib(default=None,)
+    created : float = attrib(default=None,)
+    timeout : float = attrib(default=None,)
+
+    def place(self):
+        return self.filters['main'].get('name', None)
+
+
+    def to_json(self):
+        return {
+            'owner': self.owner,
+            'state': self.state.name,
+            'prio': self.prio,
+            'filters': self.filters,
+            'allocations': self.allocations,
+            'created': self.created,
+            'timeout': self.timeout,
         }

--- a/python-wamp-client/labby/labby_types.py
+++ b/python-wamp-client/labby/labby_types.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Optional, Set, Tuple
 from autobahn.asyncio.wamp import ApplicationSession
 from attr import attrs, attrib
 
+
 TargetName = str
 ExporterName = str
 PlaceName = str
@@ -28,10 +29,11 @@ class Session(ApplicationSession):
     def __init__(self, *args, **kwargs) -> None:
         self.resources: Optional[Dict] = None
         self.places: Optional[Dict] = None
-        self.acquired_places: List = []
+        self.acquired_places: List[PlaceName] = []
         self.power_states: Optional[List] = None
         self.reservations: Dict = {}
         self.to_refresh: Set = set()
+        self.user_name : str
         super().__init__(*args, **kwargs)
 
 

--- a/python-wamp-client/labby/rpc.py
+++ b/python-wamp-client/labby/rpc.py
@@ -444,13 +444,16 @@ async def refresh_reservations(context: Session):
         for token in context.to_refresh:
             if token in context.reservations:
                 context.log.info(f"Refreshing reservation {token}")
-                if context.reservations[token]['state'] not in ('waiting', 'allocated'):
+                if context.reservations[token]['state'] in ('waiting', 'allocated'):
                     ret = await context.call("org.labgrid.coordinator.poll_reservation", token)
                     if not ret:
                         context.log.error(
                             f"Failed to poll reservation {token}.")
+                    context.reservations[token] = ret
                 else:
                     to_remove.add(token)
+            else:
+                to_remove.add(token)
         map(context.to_refresh.remove, to_remove)
         await asyncio.sleep(10)
 

--- a/python-wamp-client/labby/rpc.py
+++ b/python-wamp-client/labby/rpc.py
@@ -415,6 +415,7 @@ async def create_reservation(context: Session, place: PlaceName, priority: float
     # TODO should multiple reservations be allowed?
     if place is None:
         return invalid_parameter("Missing required parameter: place.")
+    await get_reservations(context) # get current state from coordinator
     if any((place == x['filters']['main']['name'] for x in context.reservations.values() if 'name' in x['filters']['main'])):
         return failed(f"Place {place} is already reserved.")
     await get_reservations(context)  # update existing
@@ -433,6 +434,7 @@ async def cancel_reservation(context: Session, place: PlaceName) -> Union[bool, 
         return invalid_parameter("Missing required parameter: place.")
     token = next((token for token, x in context.reservations.items()
                  if x['filters']['main']['name'] == place), None)
+    await get_reservations(context) # get current state from coordinator
     if token is None:
         return failed(f"No reservations available for place {place}.")
     del context.reservations[token]

--- a/python-wamp-client/labby/rpc.py
+++ b/python-wamp-client/labby/rpc.py
@@ -241,6 +241,12 @@ async def places(context: Session,
         return power_states
     place_res = []
     for place_name, place_data in data.items():
+        # append the place to acquired places if
+        # it has been acquired in a previous session
+        if (place_data and place_data['acquired'] == context.user_name
+            and place_name not in context.acquired_places
+            ):
+            context.acquired_places.append(place_name)
         if place is not None and place_name != place:
             continue
         # ??? (Kevin) what if there are more than one or no matches

--- a/python-wamp-client/labby/rpc.py
+++ b/python-wamp-client/labby/rpc.py
@@ -246,7 +246,7 @@ async def places(context: Session,
         if (place_data and place_data['acquired'] == context.user_name
             and place_name not in context.acquired_places
             ):
-            context.acquired_places.append(place_name)
+            context.acquired_places.add(place_name)
         if place is not None and place_name != place:
             continue
         # ??? (Kevin) what if there are more than one or no matches
@@ -369,7 +369,7 @@ async def acquire(context: Session,
     except ApplicationError as err:
         return failed(f"Got exception while trying to call org.labgrid.coordinator.acquire_place. {err}")
     if acquire_successful:
-        context.acquired_places.append(place)
+        context.acquired_places.add(place)
         # remove the reservation if there was one
         if token := next((token for token, x in context.reservations.items() if x['filters']['main']['name'] == place), None,):
             ret = await cancel_reservation(context, token)
@@ -393,10 +393,9 @@ async def release(context: Session,
     context.log.info(f"Releasing place {place}.")
     try:
         release_successful = await context.call('org.labgrid.coordinator.release_place', place)
+        context.acquired_places.remove(place)
     except ApplicationError as err:
         return failed(f"Got exception while trying to call org.labgrid.coordinator.release_place. {err}")
-    if release_successful:
-        context.acquired_places.remove(place)
     return release_successful
 
 

--- a/python-wamp-client/labby/rpc.py
+++ b/python-wamp-client/labby/rpc.py
@@ -405,12 +405,15 @@ async def get_reservations(context: Session) -> Dict:
     RPC call to list current reservations on the Coordinator
     """
     reservation_data: Dict = await context.call("org.labgrid.coordinator.get_reservations")
-    for token in context.to_refresh:
-        if token not in reservation_data:
-            context.to_refresh.remove(token)
+
+    to_remove = {
+        token for token in context.to_refresh if token not in reservation_data
+    }
+
     for token, data in reservation_data.items():
         if data['state'] != 'waiting' and token in context.to_refresh:
-            context.to_refresh.remove(token)
+            to_remove.add(token)
+    map(context.to_refresh.remove, to_remove)
     context.reservations.update(**reservation_data)
     return reservation_data
 

--- a/python-wamp-client/labby/rpc.py
+++ b/python-wamp-client/labby/rpc.py
@@ -6,7 +6,7 @@ Generic RPC functions for labby
 import asyncio
 import os
 from pathlib import Path
-from time import sleep, time
+from time import time
 from typing import Any, Callable, Dict, Iterable, List, Optional, Type, Union
 
 import yaml
@@ -445,9 +445,10 @@ async def refresh_reservations(context: Session):
             if token in context.reservations:
                 context.log.info(f"Refreshing reservation {token}")
                 if context.reservations[token]['state'] not in ('waiting', 'allocated'):
-                ret = await context.call("org.labgrid.coordinator.poll_reservation", token)
-                if not ret:
-                    context.log.error(f"Failed to poll reservation {token}.")
+                    ret = await context.call("org.labgrid.coordinator.poll_reservation", token)
+                    if not ret:
+                        context.log.error(
+                            f"Failed to poll reservation {token}.")
                 else:
                     to_remove.add(token)
         map(context.to_refresh.remove, to_remove)

--- a/python-wamp-client/tests/test_mock.py
+++ b/python-wamp-client/tests/test_mock.py
@@ -75,6 +75,7 @@ def mock_labby(func_names: List[str]):
 
 class MockSession(Session):
     def __init__(self, *args, **kwargs) -> None:
+        self.user_name = "client/labby/dummy"
         super().__init__(*args, **kwargs)
 
     @make_async

--- a/python-wamp-client/tests/test_mock.py
+++ b/python-wamp-client/tests/test_mock.py
@@ -401,20 +401,20 @@ class TestReservation(unittest.TestCase):
     @async_test
     async def test_create_reservations(self):
         context = MockSession()
-        registration = await rpc.create_reservation(context, "place1")
+        registration = await rpc.create_reservation(context, "place2")
         assert registration
         assert isinstance(registration, Dict)
-        assert next(iter(registration.values()))['filters']['main']['name'] == 'place1'
+        assert next(iter(registration.values()))['filters']['main']['name'] == 'place2'
 
     @async_test
     async def test_create_already_exists(self):
         context = MockSession()
-        registration = await rpc.create_reservation(context, "place1")
+        registration = await rpc.create_reservation(context, "place2")
         assert registration
         assert isinstance(registration, Dict)
         registration = next(iter(registration.values()))
-        assert registration['filters']['main']['name'] == 'place1'
-        registration = await rpc.create_reservation(context, 'place1')
+        assert registration['filters']['main']['name'] == 'place2'
+        registration = await rpc.create_reservation(context, 'place2')
         assert registration
         assert isinstance(registration, SerLabbyError)
         assert registration['error']['kind'] == ErrorKind.FAILED.value


### PR DESCRIPTION
# Fixes
quick fix for creating and deleting reservations, only one per place
* create_reservation checks cache before calling coordinator
* cancel_reservation returns result from labgrid coordinator
* cancel_reservation clears cache entry on success
# Todo
* testing