### PR TITLE
mock console, updated mock tests

### DIFF
--- a/python-wamp-client/labby/labby.py
+++ b/python-wamp-client/labby/labby.py
@@ -10,8 +10,8 @@ import asyncio.log
 from autobahn.asyncio.wamp import ApplicationSession, ApplicationRunner
 import autobahn.wamp.exception as wexception
 
-from .rpc import (acquire_resource, add_match, cancel_reservation, create_place, create_resource, del_match,
-                  delete_place, delete_resource, forward, get_alias, get_exporters, invalidates_cache, list_places,
+from .rpc import (acquire_resource, add_match, cancel_reservation, console, console_write, create_place, create_resource, del_match,
+                  delete_place, delete_resource, forward, get_alias, get_exporters, invalidates_cache, list_places, mock_console,
                   places, places_names, get_reservations, create_reservation, poll_reservation, refresh_reservations, release_resource, resource, power_state,
                   acquire, release, info, resource_by_name, resource_names, resource_overview)
 from .router import Router
@@ -152,7 +152,6 @@ class LabbyClient(Session):
             frontend.publish("localhost.onPlaceChanged", place_data)
 
 
-
 class RouterInterface(ApplicationSession):
     """
     Wamp router, for communicaion with frontend
@@ -214,7 +213,9 @@ class RouterInterface(ApplicationSession):
         self.register("resource_names", resource_names)
         self.register("add_match", add_match)
         self.register("del_match", del_match)
-
+        self.register("console", console)
+        self.register("console_write", console_write)
+        asyncio.create_task(mock_console(get_context_callback(), self))
 
     def onLeave(self, details):
         self.log.info("Session disconnected.")
@@ -257,5 +258,4 @@ def run_router(backend_url: str, backend_realm: str, frontend_url: str, frontend
     finally:
         frontend_coro.close()
         labby_coro.close()
-        asyncio.get_event_loop().close()
         router.stop()

--- a/python-wamp-client/labby/labby_types.py
+++ b/python-wamp-client/labby/labby_types.py
@@ -34,7 +34,8 @@ class Session(ApplicationSession):
         self.power_states: Optional[List] = None
         self.reservations: Dict = {}
         self.to_refresh: Set = set()
-        self.user_name : str
+        self.user_name: str
+        self.open_consoles: Dict = {}
         super().__init__(*args, **kwargs)
 
 
@@ -62,6 +63,8 @@ class LabbyPlace(LabbyType):
         }
 
 # pylint: disable=invalid-name
+
+
 class _ReservationState(Enum):
     waiting = 0
     allocated = 1
@@ -69,20 +72,20 @@ class _ReservationState(Enum):
     expired = 3
     invalid = 4
 
+
 @attrs
 class LabbyReservation(LabbyType):
-    owner : str = attrib(default=None,)
-    token : str = attrib(default=None,)
-    state : _ReservationState = attrib(default=None,)
-    prio : float = attrib(default=None,)
-    filters : Dict[str, Dict[str, str]]= attrib(default=None,)
-    allocations : Dict[str, str] = attrib(default=None,)
-    created : float = attrib(default=None,)
-    timeout : float = attrib(default=None,)
+    owner: str = attrib(default=None,)
+    token: str = attrib(default=None,)
+    state: _ReservationState = attrib(default=None,)
+    prio: float = attrib(default=None,)
+    filters: Dict[str, Dict[str, str]] = attrib(default=None,)
+    allocations: Dict[str, str] = attrib(default=None,)
+    created: float = attrib(default=None,)
+    timeout: float = attrib(default=None,)
 
     def place(self):
         return self.filters['main'].get('name', None)
-
 
     def to_json(self):
         return {

--- a/python-wamp-client/labby/resource.py
+++ b/python-wamp-client/labby/resource.py
@@ -2,7 +2,8 @@
 Handle resources to be sent via the router
 """
 from enum import Enum
-from typing import Dict
+from typing import Dict, Optional
+from attr import attrs, attrib
 
 
 class ResourceType(Enum):
@@ -12,53 +13,24 @@ class ResourceType(Enum):
     POWERPORTS = "PowerPorts"
 
 
-def set_exporter_url(url: str):
-    #TODO (Kevin)
-    raise NotImplementedError
-
-
-def get_exporter_url(url: str):
-    #TODO (Kevin)
-    raise NotImplementedError
-
-
-class Resource:
-    """
-    Binds RPC for a resource
-    """
+@attrs
+class LabbyResource:
+    cls: Optional[str] = attrib()
+    avail: bool = attrib(default=True)
+    params: Dict = attrib(default=None)
+    acquired: bool = attrib(default=False)
 
     def __init__(self, **kwargs):
-        self.raw_params = kwargs["params"]
+        self.props = kwargs["params"]
 
     @property
     def name(self):
-        return self.raw_params["name"]
-
-    def publish(self, place: str, router):
-        """
-        publish a resource and its rpc to a router and place
-        """
-        raise NotImplementedError
-
-    def is_available(self) -> bool:
-        """
-        Is the backed resource available to be used
-        """
-        raise NotImplementedError
+        return self.props["name"]
 
 
-def resource_from_ws(payload: Dict) -> Resource:
-    assert "params" in payload
-    return Resource()
-
-
-if __name__ == "__main__":
-
-    payload = {
-        "name": "name",
-        "matches": "",
-        "acquired": False,
-        "cls": ""
-    }
-
-    resource_from_ws(payload)
+@attrs
+class NetworkSerialPort(LabbyResource):
+    port: int = attrib(default=12345)
+    speed: int = attrib(default=115200)
+    protocol: str = attrib(default='rfc2217')
+    host: Optional[str] = attrib(default=None)

--- a/python-wamp-client/labby/rpc.py
+++ b/python-wamp-client/labby/rpc.py
@@ -12,6 +12,8 @@ import yaml
 from attr import attrib, attrs
 from autobahn.wamp.exception import ApplicationError
 
+from labby.resource import LabbyResource, NetworkSerialPort
+
 from .labby_error import (LabbyError, failed, invalid_parameter,
                           not_found)
 from .labby_types import (ExporterName, GroupName, LabbyPlace, PlaceName, PowerState, Resource,
@@ -253,7 +255,7 @@ async def places(context: Session,
         # append the place to acquired places if
         # it has been acquired in a previous session
         if (place_data and place_data['acquired'] == context.user_name
-                and place_name not in context.acquired_places
+                    and place_name not in context.acquired_places
                 ):
             context.acquired_places.add(place_name)
         if place is not None and place_name != place:
@@ -552,8 +554,79 @@ async def reset(context: Session, place: PlaceName) -> bool:
     return False
 
 
-async def console(context: Session, *args):
-    pass
+@labby_serialized
+async def console(context: Session, place: PlaceName):
+    # TODO allow selection of resource to connect console to
+    if place is None:
+        return invalid_parameter("Missing required parameter: place.")
+    if place not in context.acquired_places:
+        ret = await acquire(context, place)
+        if isinstance(ret, LabbyError):
+            return ret
+        if not ret:
+            return failed("Failed to acquire Place (It may already have been acquired).")
+    if place in context.open_consoles:
+        return failed(f"There is already a console open for {place}.")
+    # check that place has a console
+    _resources = await fetch_resources(context, place, resource_key=None)
+    if isinstance(_resources, LabbyError):
+        return _resources
+    if len(_resources) == 0:
+        return failed(f"No resources on {place}.")
+    _resources = flatten(_resources, depth=2)  # remove exporter and place
+    _resource: Optional[LabbyResource] = next(
+        (
+            NetworkSerialPort(
+                cls=data['cls'],
+                port=data['params']['port'],
+                host=data['params']['host'],
+                speed=data['params']['speed'],
+                protocol=data['params'].get('protocol', 'rfc2217'),
+            )
+            for _, data in _resources.items()
+            if 'cls' in data and data['cls'] == 'NetworkSerialPort'
+        ),
+        None,
+    )
+    if _resource is None:
+        return failed(f"No network serial port on {place}.")
+    assert isinstance(_resource, NetworkSerialPort)
+
+    context.open_consoles[place] = True  # mock data
+    return True
+
+
+@labby_serialized
+async def console_write(context: Session, place: PlaceName, data: str) -> Union[bool, LabbyError]:
+    # TODO implement
+    if place not in context.acquired_places:
+        return failed(f"Place {place} is not acquired.")
+    if not context.open_consoles.get(place):
+        return failed(f"Place {place} has no open consoles.")
+    #
+    # do stuff
+    #
+    context.log.info(f"Console on {place} received: {data}.")
+    return True
+
+
+@labby_serialized
+async def console_close(context: Session, place: PlaceName) -> Optional[LabbyError]:
+    if place not in context.acquired_places:
+        return failed(f"Place {place} is not acquired.")
+    if not context.open_consoles.get(place):
+        return failed(f"Place {place} has no open consoles.")
+    del context.open_consoles[place]
+
+
+async def mock_console(context: Session, frontend):
+    from random import random, choice
+    phrases = ["Hello", "lorem ipsum ...", "Dies ist ein test!", "Mock Mock"]
+    while True:
+        await asyncio.sleep(2. + random() * 2)
+        for place in context.open_consoles:
+            frontend.publish(f"localhost.consoles.{place}",
+                             f"{context.user_name}@{place}> {choice(phrases)}")
 
 
 async def video(context: Session, *args):

--- a/python-wamp-client/tests/test_mock.py
+++ b/python-wamp-client/tests/test_mock.py
@@ -267,15 +267,17 @@ class TestLabby(unittest.TestCase):
     """
     mock test labby
     """
-
-    def test_on_join(self) -> None:
+    @async_test
+    @patch("asyncio.create_task")
+    @patch.object(ApplicationSession, "call", make_async(MagicMock()))
+    async def test_on_join(self, ct) -> None:
         """
         Test onJoin callback function, mock ApplicationSession Super class
         """
         # TODO test criteria
         client = LabbyClient()
         client.subscribe = mock.MagicMock()
-        client.onJoin(details=None)
+        await client.onJoin(details=None)
 
     def test_on_leave(self) -> None:
         """
@@ -368,7 +370,9 @@ class TestFrontendRouter(unittest.TestCase):
         client.disconnect = mock.MagicMock()
         client.onLeave(details=None)
 
-    def test_on_join(self) -> None:
+    @patch("asyncio.create_task")
+    @patch.object(ApplicationSession, "call", make_async(MagicMock()))
+    def test_on_join(self, ct) -> None:
         client = RouterInterface()
         client.register = MagicMock()
         client.onJoin(details=None)


### PR DESCRIPTION
# Added
* rpc `localhost.console(place)` opens a console on place
    * requires a place to not be acquired by a different user (but can be unaquired)
    * there needs to be a network serial port as a resource on that place
* rpc  `localhost.console_write(place, data)`
    * requires a open console on place
    * place has to be acquired
* background task creating mock console data for topic `localhost.consoles.<place name>`
