### PR TITLE
Fix Missing rpc call to close console

### DIFF
--- a/python-wamp-client/labby/labby.py
+++ b/python-wamp-client/labby/labby.py
@@ -10,7 +10,7 @@ import asyncio.log
 from autobahn.asyncio.wamp import ApplicationSession, ApplicationRunner
 import autobahn.wamp.exception as wexception
 
-from .rpc import (acquire_resource, add_match, cancel_reservation, console, console_write, create_place, create_resource, del_match,
+from .rpc import (acquire_resource, add_match, cancel_reservation, console, console_close, console_write, create_place, create_resource, del_match,
                   delete_place, delete_resource, forward, get_alias, get_exporters, invalidates_cache, list_places, mock_console,
                   places, places_names, get_reservations, create_reservation, poll_reservation, refresh_reservations, release_resource, resource, power_state,
                   acquire, release, info, resource_by_name, resource_names, resource_overview)
@@ -215,6 +215,7 @@ class RouterInterface(ApplicationSession):
         self.register("del_match", del_match)
         self.register("console", console)
         self.register("console_write", console_write)
+        self.register("console_close", console_close)
         asyncio.create_task(mock_console(get_context_callback(), self))
 
     def onLeave(self, details):

--- a/python-wamp-client/labby/rpc.py
+++ b/python-wamp-client/labby/rpc.py
@@ -626,7 +626,7 @@ async def mock_console(context: Session, frontend):
         await asyncio.sleep(2. + random() * 2)
         for place in context.open_consoles:
             frontend.publish(f"localhost.consoles.{place}",
-                             f"{context.user_name}@{place}> {choice(phrases)}")
+                             {choice(phrases)})
 
 
 async def video(context: Session, *args):


### PR DESCRIPTION
# Added
* rpc `localhost.console_close(place)` to close a open console on `place`