### PR TITLE
cli command rpc

### DIFF
--- a/python-wamp-client/labby/labby.py
+++ b/python-wamp-client/labby/labby.py
@@ -12,7 +12,7 @@ import asyncio.log
 from autobahn.asyncio.wamp import ApplicationSession, ApplicationRunner
 import autobahn.wamp.exception as wexception
 
-from .rpc import (acquire_resource, add_match, cancel_reservation, console, console_close, console_write, create_place, create_resource, del_match,
+from .rpc import (acquire_resource, add_match, cancel_reservation, cli_command, console, console_close, console_write, create_place, create_resource, del_match,
                   delete_place, delete_resource, forward, get_alias, get_exporters, invalidates_cache, list_places,
                   places, places_names, get_reservations, create_reservation, poll_reservation, refresh_reservations, release_resource, resource, power_state,
                   acquire, release, info, resource_by_name, resource_names, resource_overview)
@@ -232,6 +232,7 @@ class RouterInterface(ApplicationSession):
         self.register("console", console)
         self.register("console_write", console_write)
         self.register("console_close", console_close)
+        self.register("cli_command", cli_command)
 
     def onLeave(self, details):
         self.log.info("Session disconnected.")

--- a/python-wamp-client/labby/prompty.py
+++ b/python-wamp-client/labby/prompty.py
@@ -1,7 +1,32 @@
 import asyncio
 import contextlib
+from pprint import pprint
 import sys
-from labby.labby import frontend_sessions, run_router
+import shlex
+# from labby.labby import frontend_sessions, run_router
+
+from autobahn.asyncio.wamp import ApplicationSession, ApplicationRunner
+
+session = None
+
+
+class Component(ApplicationSession):
+    """
+    An application component that subscribes and receives events.
+    After receiving 5 events, it unsubscribes, sleeps and then
+    resubscribes for another run. Then it stops.
+    """
+
+    def __init__(self, config=None):
+        super().__init__(config)
+        globals()["session"] = self
+
+    async def onJoin(self, details):
+        await self.subscribe(lambda x: print(f"onResourceChanged got: {x}"), "localhost.onResourceChanged")
+        await self.subscribe(lambda x: print(f"onPlaceChanged    got: {x}"), "localhost.onPlaceChanged")
+
+    def onDisconnect(self):
+        asyncio.get_event_loop().stop()
 
 
 async def ainput(string: str) -> str:
@@ -13,28 +38,31 @@ async def ainput(string: str) -> str:
 
 
 def _parse(command: str):
-    cmd_list = command.replace('\\n', '\n').strip().split(' ')
+    cmd_list = shlex.split(command.strip())
     cmd_list[0] = f"localhost.{cmd_list[0]}"
     for i, s in enumerate(cmd_list):
         if '=' in s:
             a, b = s.split('=')
             cmd_list[i] = {a.strip(): b.strip()}
+        if '.!' in s:
+            cmd_list[i] = cmd_list[i].replace('.!', chr(28))
     return cmd_list
 
 
 async def prompty():
     count = 0
     while True:
-        while len(frontend_sessions) == 0:
+        while session is None:
             print(f'Waiting for labby... {count}', end='\r')
             count += 1
             await asyncio.sleep(delay=1)
+        print()
         command = await ainput('command: ')
-        callback = frontend_sessions[0]
+        callback = session
         try:
             if command and callback is not None:
                 ret = await callback.call(*_parse(command))
-                print(f"got>\n {ret}\n")
+                pprint(ret)
         except:
             pass
 
@@ -43,5 +71,21 @@ def run(backend_url, backend_realm, frontend_url, frontend_realm, keyfile_path, 
     with contextlib.suppress(KeyboardInterrupt):
         loop = asyncio.get_event_loop()
         asyncio.run_coroutine_threadsafe(prompty(), loop)
-        run_router(backend_url, backend_realm,
-                   frontend_url, frontend_realm, keyfile_path, remote_url)
+        # run_router(backend_url, backend_realm,
+        #            frontend_url, frontend_realm, keyfile_path, remote_url)
+        url = "ws://localhost:8083/ws"
+        realm = "frontend"
+
+
+def main():
+    with contextlib.suppress(KeyboardInterrupt):
+        loop = asyncio.get_event_loop()
+        asyncio.run_coroutine_threadsafe(prompty(), loop)
+        url = "ws://localhost:8083/ws"
+        realm = "frontend"
+        runner = ApplicationRunner(url, realm)
+        coro = runner.run(Component)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Added
* rpc call to issue labgrid-client commands on remote host
* added rpc endpoint: `localhost.cli_command(command) -> str`  which issues the command `labgrid-client <command>` and returns the output as string